### PR TITLE
Ca file optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'puppetlabs_spec_helper', '>= 2.14.0',                        :require => false
   gem 'rspec-puppet-facts', '>= 1.9.5',                             :require => false
   gem 'rspec-puppet-utils',                                         :require => false
-  gem 'pdk',                                                        :require => false
+  gem 'pdk', '>= 1.14.0',                                           :require => false
   gem 'puppet-module',                                              :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -69,8 +69,7 @@ module PuppetX
 
       if tls
         conf[:encryption] = {
-          method: :simple_tls,
-          tls_options: { ca_file: ca_file }
+          method: :simple_tls
         }
         if File.file?(ca_file)
           conf[:encryption][:tls_options] = { ca_file: ca_file }

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -72,6 +72,9 @@ module PuppetX
           method: :simple_tls,
           tls_options: { ca_file: ca_file }
         }
+        if File.file?(ca_file)
+          conf[:encryption][:tls_options] = { ca_file: ca_file }
+        end
       end
 
       conf

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -52,8 +52,6 @@ module PuppetX
       tls = Puppet[:ldaptls]
       ca_file = "#{Puppet[:confdir]}/ldap_ca.pem"
 
-      # TODO: if not exists ldap_ca.pem fail
-
       conf = {
         host: host,
         port: port
@@ -72,7 +70,10 @@ module PuppetX
           method: :simple_tls
         }
         if File.file?(ca_file)
+          Puppet.debug("Using #{ca_file} as CA for TLS connection")
           conf[:encryption][:tls_options] = { ca_file: ca_file }
+        else
+          Puppet.debug("#{ca_file} not found, using default CAs installed in your system")
         end
       end
 


### PR DESCRIPTION
This PR makes CA file usage conditional based on if it exists or not.
We use let's encrypt certs for our LDAP servers and so their CA is standard enough to not to be specified while building LDAP client.