### PR TITLE
Put options for ldapquery into opts argument

### DIFF
--- a/lib/puppet/parser/functions/ldapquery.rb
+++ b/lib/puppet/parser/functions/ldapquery.rb
@@ -17,15 +17,17 @@ end
 Puppet::Parser::Functions.newfunction(:ldapquery,
                                       type: :rvalue) do |args|
 
-  if args.size > 4
+  if args.size > 3
     raise Puppet::ParseError, 'Too many arguments received in ldapquery()'
   end
 
-  filter, attributes, base, scope = args
+  filter, attributes, opts = args
 
   attributes ||= []
-  base ||= Puppet[:ldapbase]
-  scope ||= 'sub'
+  opts ||= {}
+  base = opts['base'] || Puppet[:ldapbase]
+  scope = opts['scope'] || 'sub'
+  server = opts['server'] || Puppet[:ldapserver]
 
-  return PuppetX::LDAPquery.new(filter, attributes, base, scope).results
+  return PuppetX::LDAPquery.new(filter, attributes, base, scope, server).results
 end

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -9,11 +9,13 @@ module PuppetX
       filter,
       attributes = [],
       base = Puppet[:ldapbase],
-      scope = 'sub'
+      scope = 'sub',
+      server = Puppet[:ldapserver]
     )
       @filter = filter
       @attributes = attributes
       @base = base
+      @host = server
 
       return unless scope
 
@@ -41,7 +43,6 @@ module PuppetX
         end
       end
 
-      host = Puppet[:ldapserver]
       port = Puppet[:ldapport]
 
       if Puppet[:ldapuser] && Puppet[:ldappassword]
@@ -53,7 +54,7 @@ module PuppetX
       ca_file = "#{Puppet[:confdir]}/ldap_ca.pem"
 
       conf = {
-        host: host,
+        host: @host,
         port: port
       }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Move connection options for `ldapquery` into a hash of options to avoid having to specify a bunch of options when all that is needed is to specify something like unique LDAP server.

Example usage we have been using in production:

```
if $facts['puppet_environment'] in ['production','next'] {
    $ldapquery_opts = {'server' => $ldapservers['production'][0]}
  } else {
    $ldapquery_opts = {'server' => $ldapservers['test'][0]}
  }

$ldap_projects = ldapquery('(&(objectClass=oscGroup)(!(ou=ENTITLEMENT))(!(ou=SOFTWARE)))', ['cn','o','ou','status','properties'], $ldapquery_opts)
```

We have a single set of Puppet masters for many environments and those environments have different LDAP servers that are just test/production versions of our LDAP all using the same Puppet masters.  Rather than add a new `ldapserver` argument to `ldapquery` and having to then specify `sub` and `base` which would be extremely verbose, using an options hash allows for specifying individual overrides and then the rest come from defaults specified on master.

This would be a breaking change to this module.