### PR TITLE
Do explicit string conversion on values too

### DIFF
--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -129,7 +129,7 @@ module PuppetX
           attr = attribute.to_s
           value_data = []
           Array(values).flatten.each do |v|
-            value_data << v.chomp
+            value_data << v.to_s.chomp
           end
           entry_data[attr] = value_data
         end


### PR DESCRIPTION
`to_s` the values too (like the attribute in line 129). This prevents the copious logging of lines like

```
 [puppetserver] Puppet Ssh_authorized_key[arjen-ssh-rsa]['user']['key']['type'] contains a Net::BER::BerIdentifiedString value. It will be converted to the String 'ssh-rsa'
```

for each and every piece of data that gets used from the `ldapquery` results.


#### Pull Request (PR) description
Convert values to string, to prevent puppetserver from logging its automatic conversion

#### This Pull Request (PR) fixes the following issues

