### PR TITLE
Rename `Net::LDAP::LdapError` to `Net::LDAP::Error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Puppet function to query LDAP.
 
 ## Dependencies
 
-The Ruby `net-ldap` gem is required to communicate with LDAP. The current version of net-ldap requires ruby 2.0.0. If you run your master with puppetserver you have to use version 0.12.1 which is the last version compatible with ruby 1.9 which is used by puppetserver. To install this use the following command: `puppetserver gem install net-ldap -v 0.12.1`
+The Ruby `net-ldap` gem is required to communicate with LDAP. To install this use the following command: `puppetserver gem install net-ldap`.  Version 0.11.0 or newer of `net-ldap` is required.
 
 In some environments, when `ldapquery()` is used on Puppet Server, an error
 like the following may appear.

--- a/lib/puppet_x/ldapquery.rb
+++ b/lib/puppet_x/ldapquery.rb
@@ -114,7 +114,7 @@ module PuppetX
 
         Puppet.debug("ldapquery(): Searching #{@base} for #{@attributes} using #{@filter} took #{time_delta} seconds and returned #{entries.length} results")
         entries
-      rescue Net::LDAP::LdapError => e
+      rescue Net::LDAP::Error => e
         Puppet.debug("There was an error searching LDAP #{e.message}")
         Puppet.debug('Returning false')
         false


### PR DESCRIPTION
The net-ldap gem deprecated `Net::LDAP::LdapError` and renamed it to `Net::LDAP::Error` starting with version [0.11] (released on Jan 21st, 2015).

Version [0.17] (released on Nov 29th, 2020) removed the deprecaded `Net::LDAP::LdapError` class.

Update the module to use the new class and unbreak the module when using a recent version of net-ldap.

[0.11]:https://github.com/ruby-ldap/ruby-net-ldap/commit/a6d6ec8285f2548fa0c08169ecc65b112922c5bd
[0.17]:https://github.com/ruby-ldap/ruby-net-ldap/commit/94b9d4d0443b8be37b91fcb5d6a31a9589cca41a