### PR TITLE
Add replacement ldapquery::search function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,4 @@
 ---
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 name: CI
 
 on: pull_request
@@ -11,6 +8,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  puppet:
-    name: Puppet
-    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
+  setup_matrix:
+    name: 'Setup Test Matrix'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    outputs:
+      puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
+      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
+    env:
+      BUNDLE_WITHOUT: development:system_tests:release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+      - name: Run static validations
+        run: bundle exec rake validate lint check
+      - name: Run rake rubocop
+        run: bundle exec rake rubocop
+      - name: Setup Test Matrix
+        id: get-outputs
+        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround false
+
+  unit:
+    needs: setup_matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
+    env:
+      BUNDLE_WITHOUT: development:system_tests:release
+      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
+    name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake parallel_spec
+
+  acceptance:
+    needs: setup_matrix
+    runs-on: ubuntu-20.04
+    env:
+      BUNDLE_WITHOUT: development:test:release
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
+    name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+      - name: Start openldap
+        run: ./spec/scripts/start-openldap.sh
+      - name: Run tests
+        run: bundle exec rake beaker
+        env:
+          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}
+      - name: openldap logs
+        run: docker logs openldap --tail 50
+        if: always()
+
+
+  tests:
+    needs:
+      - unit
+      - acceptance
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,8 +1,11 @@
+---
 Gemfile:
   optional:
     ':extra':
       - gem: 'net-ldap'
-        version: '~> 0.16.1'
+        version: '~> 0.18.0'
     ':testextra':
       - gem: 'rspec-mocks'
       - gem: 'rspec-expectations'
+.github/workflows/ci.yml:
+    unmanaged: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Puppet function to query LDAP.
 
 The Ruby `net-ldap` gem is required to communicate with LDAP. To install this use the following command: `puppetserver gem install net-ldap`.  Version 0.11.0 or newer of `net-ldap` is required.
 
-In some environments, when `ldapquery::query()` is used on Puppet Server, an error
+In some environments, when `ldapquery::search()` is used on Puppet Server, an error
 like the following may appear.
 
     Error while evaluating a Function Call
@@ -21,9 +21,125 @@ like the following may appear.
 Please make sure you have `jruby-openssl` at least `0.10.1` with `puppetserver
 gem install jruby-openssl -v 0.10.1`.
 
-## Sample Usage
+## REFERENCE
 
-### On the Puppetserver
+For detailed information on this module's functions, see the [REFERENCE.md](https://github.com/voxpupuli/puppet-ldapquery/blob/master/REFERENCE.md)
+
+## Usage
+
+This module provides two function variants. ``ldapquery::query`` is the legacy implementation where LDAP connection options are sourced from `puppet.conf` on your Puppetserver.
+
+`ldapquery::search` is the replacement implementation. It provides more flexibility than `ldapquery::query` and doesn't reuse `ldap` related settings from `puppet.conf`. All connection options can be specified in the function call and can be different each time you call the function. For convenience, it is also possible to specify defaults to be used in all functions calls in `/etc/puppetlabs/puppet/ldapquery.yaml`. This can also be useful if you want to manage the credentials used to contact your ldap server separately from the code that calls the function.
+
+### Simple example
+
+```pupppet
+ldapquery::search(
+  'dc=acme,dc=example,dc=com', # Search base
+  '(objectClass=dnsDomain)',   # filter
+  ['dc'],                      # attributes
+  {                            # connection arguments
+    host => 'ldap.example.com',
+    auth => {
+      method   => simple,
+      username => 'ldapuser',
+      password => 'ldappassword',
+    },
+  },
+)
+
+```
+
+A full set of examples can be found in the [REFERENCE.md](https://github.com/voxpupuli/puppet-ldapquery/blob/master/REFERENCE.md) file.
+
+### LDAP connection arguments
+
+LDAP server connection options either have to be specified when calling the function, (in the 4th argument), or configured as defaults on the puppetserver in `/etc/puppetlabs/puppet/ldapquery.yaml`
+
+Everything that the `net-ldap` library supports should work with this function, (eg. connecting to multiple LDAP servers, using TLS etc.) The REFERENCE.MD file has many examples. The examples that follow have omitted this option for simplicity. It can be assumed they have been configured on the puppetserver.
+
+### Filters and attributes
+
+Simply passing the search base and an `rfc4515` search filter string to `ldapquery::search()` will return
+the results of the query in list form.  Optionally, a list of attributes of which to return the values may also be passed.
+
+Consider the following manifest. (For simplicity, the declaration of `$ldap_args` has been left off of the following examples).
+
+```Puppet
+$base = 'dc=acme,dc=example,dc=com'
+
+$filter = '(uid=zach)'
+
+$attributes = [
+  'loginshell',
+  'uidnumber',
+  'uid',
+  'homedirectory',
+]
+
+$zach = ldapquery::search($base, $filter, $attributes)
+```
+
+Assuming there is only one LDAP object with the `uid=zach`, then the variable
+`$zach` now holds the following data structure:
+
+```Ruby
+[
+  {
+    'uid'           => ['zach'],
+    'loginshell'    => ['/bin/zsh'],
+    'uidnumber'     => ['123'],
+    'homedirectory' => ['/var/users/zach'],
+  }
+]
+```
+
+**Note that the key values are an array.**  This should make implementation code simpler, if a bit more verbose, and avoid having to check if the value is an array or a string, because it always is.
+
+Here is a slightly more complicated example that will generate *virtual*
+`ssh_authorized_key` resources for every 'posixAccount' that has a non-empty
+'sshPublicKey' attribute.
+
+```Puppet
+$base = 'dc=acme,dc=example,dc=com'
+
+$attributes = [
+  'uid',
+  'sshPublicKey'
+]
+
+$key_query = '(&(objectClass=ldapPublicKey)(sshPublicKey=*)(objectClass=posixAccount))'
+
+$key_results = ldapquery::search($base, $key_query, $attributes)
+$key_results.each |$u| {
+  any2array($u['sshpublickey']).each |$k| {
+    $keyparts = split($k, ' ')
+
+    # Retrieve the comment portion
+    if $keyparts =~ Array[String, 3] {
+      $comment  = $keyparts[2]
+    } else {
+      $comment  = ''
+    }
+
+    $uid = $u['uid'][0]
+
+    @ssh_authorized_key { "${uid}_${comment}":
+      user => $uid,
+      type => $keyparts[0],
+      key  => $keyparts[1],
+      tag  => 'ldap',
+    }
+  }
+}
+```
+
+
+### The legacy function `ldapquery::query`
+
+This implementation has been replaced by the more advanced version `ldapquery::search` documented above. It should be considered DEPRECATED and may be removed in a future release.  For completeness, documentation specific to this function is retained in this release and follows.
+
+#### On the Puppetserver
 
 You must set the necessary variables in `puppet.conf` so the puppetserver can connect
 to your LDAP server. You also have to place the CA certificate (and possible intermediate certificates) of the tls certificate of your ldap server in pem format in a file called ldap_ca.pem in your puppetconf folder.
@@ -94,76 +210,5 @@ ini_setting { 'ldappassword':
 ini_setting { 'ldaptls':
   setting => 'ldaptls',
   value   => true,
-}
-```
-
-### In manifest
-
-Simply passing an `rfc4515` search filter string to `ldapquery::query()` will return
-the results of the query in list form.  Optionally, a list of attributes of
-which to return the values may also be passed.
-
-Consider the following manifest.
-
-```Puppet
-$attributes = [
-  'loginshell',
-  'uidnumber',
-  'uid',
-  'homedirectory',
-]
-
-$zach = ldapquery::query('(uid=zach)', $attributes)
-```
-
-Assuming there is only one LDAP object with the `uid=zach`, then the variable
-`$zach` now holds the following data structure:
-
-```Ruby
-[
-  {
-    'uid' => ['zach'],
-    'loginshell' => ['/bin/zsh'],
-    'uidnumber' => ['123'],
-    'homedirectory' => ['/var/users/zach'],
-  }
-]
-```
-
-**Note that the key values are an array.**  This should make implementation code simpler, if a bit more verbose, and avoid having to check if the value is an array or a string, because it always is.
-
-Here is a slightly more complicate example that will generate *virtual*
-`ssh_authorized_key` resources for every 'posixAccount' that has a non-empty
-'sshPublicKey' attribute.
-
-```Puppet
-$attributes = [
-  'uid',
-  'sshPublicKey'
-]
-
-$key_query = '(&(objectClass=ldapPublicKey)(sshPublicKey=*)(objectClass=posixAccount))'
-
-$key_results  = ldapquery::query($key_query, $attributes)
-$key_results.each |$u| {
-  any2array($u['sshpublickey']).each |$k| {
-    $keyparts = split($k, ' ')
-
-    # Retrieve the comment portion
-    if $keyparts =~ Array[String, 3] {
-      $comment  = $keyparts[2]
-    } else {
-      $comment  = ''
-    }
-
-    $uid = $u['uid'][0]
-
-    @ssh_authorized_key { "${uid}_${comment}":
-      user => $uid,
-      type => $keyparts[0],
-      key  => $keyparts[1],
-      tag  => 'ldap',
-    }
-  }
 }
 ```

--- a/lib/puppet/functions/ldapquery.rb
+++ b/lib/puppet/functions/ldapquery.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-# @summary DEPRECATED.  Use the namespaced function [`ldapquery::query`](#ldapqueryquery) instead.
+# @summary DEPRECATED.  Use the namespaced function [`ldapquery::query`](#ldapqueryquery) instead or migrate to the replacement [`ldapquery::search`](#ldapquerysearch) function instead.
 Puppet::Functions.create_function(:ldapquery) do
   dispatch :deprecation_gen do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'ldapquery', 'This function is deprecated, please use ldapquery::query instead.')
+    call_function('deprecation', 'ldapquery', 'This function is deprecated, please use `ldapquery::query` or its replacement `ldapquery::search` instead.')
     call_function('ldapquery::query', *args)
   end
 end

--- a/lib/puppet/functions/ldapquery/query.rb
+++ b/lib/puppet/functions/ldapquery/query.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# @summary Provides a query interface to an LDAP server
+# @summary Provides a legacy query interface to an LDAP server
+# This function uses LDAP connection options sourced from `puppet.conf` and is **DEPRECATED**. Consider migrating to `ldapquery::search` instead.
 Puppet::Functions.create_function(:'ldapquery::query') do
   begin
     require 'net/ldap'

--- a/lib/puppet/functions/ldapquery/search.rb
+++ b/lib/puppet/functions/ldapquery/search.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+# @summary Provides a search query interface to LDAP server(s). This function is a replacement for `ldapquery::query`.
+Puppet::Functions.create_function(:'ldapquery::search') do
+  begin
+    require 'net/ldap'
+  rescue StandardError
+    Puppet.warn('Missing net/ldap gem required for ldapquery::search() function')
+  end
+
+  local_types do
+    type 'LDAPArgs = Hash' # TODO: Turn this into an exciting struct?
+  end
+
+  # @param base
+  #   The search base to use for this query.  If set to `undef`, the `base` must be set as a default in `ldapquery.yaml` instead.
+  # @param filter
+  #   The LDAP search filter to use during the query. If set to `undef`, the default `objectclass=*` will be used.
+  # @param attributes
+  #   The LDAP attributes to return from the server.
+  # @param ldap_args
+  #   A Hash containing the options used when connecting to the LDAP server(s). See the [net-ldap documentation](https://www.rubydoc.info/github/ruby-ldap/ruby-net-ldap/Net%2FLDAP:initialize) for all the options you can use.
+  #   This configuration is merged with, (and overrides), any options loaded from `/etc/puppetlabs/puppet/ldapquery.yaml`.  If omitted, `ldapquery.yaml` must contain all the options you need.
+  # @param scope
+  #   The LDAP search scope, (indicates the set of entries at or below the search base DN that may be considered potential matches for a search operation).
+  # @param search_timeout
+  #   The maximum time in seconds allowed for a search. If not specified, defaults to 10 seconds.
+  #   Note, there is a separate net-ldap TCP `connect_timout` (defaulting to 5 seconds) that can be specified via `ldap_args`, (or globally via `ldapquery.yaml`).
+  # @param soft_fail
+  #   When set to `true`, the function will return `undef` if it experiences an issue connecting to the LDAP server of performing the query.
+  #   Defaults to `false`, which causes the function to fail with an exception if it can't return the requested data.
+  #
+  # @return [Array[String]] The returned query results.
+  # @return [Undef] Returns `undef` if `soft_fail` was set to `true` and an error was encountered.
+  #
+  # @example Querying an LDAP server on the default port with a username and password
+  #   ldapquery::search(
+  #     'dc=acme,dc=example,dc=com',
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {
+  #       host => 'ldap.example.com',
+  #       auth => {
+  #         method   => simple,
+  #         username => 'ldapuser',
+  #         password => 'ldappassword',
+  #       },
+  #     },
+  #   )
+  # @example Trying to connect to multiple LDAP servers to perform the search
+  #   ldapquery::search(
+  #     'dc=acme,dc=example,dc=com',
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {
+  #       hosts => [
+  #         [ldap1.example.com, 389],
+  #         [ldap2.example.com, 389],
+  #       ],
+  #       auth => {
+  #         method   => simple,
+  #         username => 'ldapuser',
+  #         password => 'ldappassword',
+  #       },
+  #     },
+  #   )
+  # @example Not specifying `ldap_args` as all options needed exist in `ldapquery.yaml`.
+  #   # /etc/puppetlabs/puppet/ldapquery.yaml
+  #   # ---
+  #   # base: dc=acme,dc=example,dc=com
+  #   # host: ldap.example.com
+  #   # auth:
+  #   #   method: simple
+  #   #   username: ldapuser
+  #   #   password: ldappassword
+  #
+  #   ldapquery::search(
+  #     undef, # `base` can also be set in `ldapquery.yaml`
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #   )
+  # @example Querying an LDAP server using TLS and the system cert store
+  #   ldapquery::search(
+  #     'dc=acme,dc=example,dc=com',
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {
+  #       host       => 'ldap.example.com',
+  #       port       => 636,
+  #       encryption => {
+  #         method => simple_tls,
+  #       },
+  #       auth       => {
+  #         method   => simple,
+  #         username => 'ldapuser',
+  #         password => 'ldappassword',
+  #       },
+  #     },
+  #   )
+  # @example Querying an LDAP server using TLS with a custom CA certificate
+  #   ldapquery::search(
+  #     'dc=acme,dc=example,dc=com',
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {
+  #       host       => 'ldap.example.com',
+  #       port       => 636,
+  #       encryption => {
+  #         method      => simple_tls,
+  #         tls_options => { ca_file => '/path/to/custom-ca.crt' },
+  #       },
+  #       auth       => {
+  #         method   => simple,
+  #         username => 'ldapuser',
+  #         password => 'ldappassword',
+  #       },
+  #     },
+  #   )
+  # @example Querying an LDAP server on the standard port but then encrypting all traffic using STARTTLS
+  #   ldapquery::search(
+  #     'dc=acme,dc=example,dc=com',
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {
+  #       host       => 'ldap.example.com',
+  #       port       => 389, # Default included for clarity
+  #       encryption => {
+  #         method => start_tls,
+  #       },
+  #       auth       => {
+  #         method   => simple,
+  #         username => 'ldapuser',
+  #         password => 'ldappassword',
+  #       },
+  #     },
+  #   )
+  # @example Specifying a 1 minute `search_timeout`, (and `connect_timeout` via `ldapquery.yaml`)
+  #   # /etc/puppetlabs/puppet/ldapquery.yaml
+  #   # ---
+  #   # base: dc=acme,dc=example,dc=com
+  #   # host: ldap.example.com
+  #   # auth:
+  #   #   method: simple
+  #   #   username: ldapuser
+  #   #   password: ldappassword
+  #   # connect_timeout: 30
+  #
+  #   ldapquery::search(
+  #     undef, # Use `base` from `ldapquery.yaml`
+  #     '(objectClass=dnsDomain)',
+  #     ['dc'],
+  #     {}, # Use `ldapquery.yaml`
+  #     'sub',
+  #     60,
+  #   )
+  dispatch :search do
+    param 'Optional[String[1]]', :base
+    param 'Optional[String[1]]', :filter
+    optional_param 'Array[String[1],1]', :attributes
+    optional_param 'Optional[LDAPArgs]', :ldap_args
+    optional_param 'Optional[Enum["sub","base","single"]]', :scope
+    optional_param 'Optional[Integer[1]]', :search_timeout
+    optional_param 'Optional[Boolean]', :soft_fail
+    return_type 'Optional[Array]'
+  end
+
+  def search(base, filter, attributes = nil, ldap_args = nil, scope = nil, search_timeout = nil, soft_fail = nil)
+    # Set the defaults for optional_params in the code instead of function signature so that they can be omitted _or_ set to `undef`
+    attributes = [] if attributes.nil?
+    ldap_args = {} if ldap_args.nil?
+    scope = 'sub' if scope.nil?
+    search_timeout = 10 if search_timeout.nil?
+    soft_fail = false if soft_fail.nil?
+
+    conf = yaml_conf.merge(ldap_args)
+
+    conf.transform_keys!(&:to_sym)
+    conf.each do |_k, v|
+      v.transform_keys!(&:to_sym) if v.is_a? Hash
+    end
+
+    conf[:encryption][:method] = conf[:encryption][:method].to_sym if conf.dig(:encryption, :method)
+    conf[:auth][:method] = conf[:auth][:method].to_sym if conf.dig(:auth, :method)
+
+    ldap = Net::LDAP.new(conf)
+
+    search_args = {
+      base: base,
+      attributes: attributes,
+      scope: scope_object(scope),
+      time: search_timeout,
+      return_result: false,
+    }.compact
+
+    search_args[:filter] = Net::LDAP::Filter.construct(filter) if filter
+
+    perform_search(ldap, search_args, soft_fail)
+  end
+
+  def yaml_conf
+    yamlfile = "#{Puppet.settings[:confdir]}/ldapquery.yaml"
+    return {} unless File.exist? yamlfile
+
+    Puppet.debug("ldapquery::search(): Loading default settings from #{yamlfile}")
+    YAML.load_file(yamlfile)
+  end
+
+  def scope_object(scope)
+    case scope
+    when 'sub'
+      Net::LDAP::SearchScope_WholeSubtree
+    when 'base'
+      Net::LDAP::SearchScope_BaseObject
+    when 'single'
+      Net::LDAP::SearchScope_SingleLevel
+    end
+  end
+
+  def perform_search(ldap, search_args, soft_fail)
+    results = []
+
+    start_time = Time.now
+
+    begin
+      if ldap.search(search_args) { |entry| results << format_entry(entry) }
+        Puppet.debug "ldapquery::search(:) LDAP search result was #{ldap.get_operation_result.code}:#{ldap.get_operation_result.message}"
+      else
+        message = "ldapquery::search(): LDAP search FAILED with #{ldap.get_operation_result.code}:#{ldap.get_operation_result.message}"
+        raise Puppet::ParseError, message unless soft_fail
+
+        Puppet.warning message
+        return nil
+      end
+    rescue Net::LDAP::Error, Net::LDAP::ConnectionError => e
+      raise e unless soft_fail
+
+      Puppet.warning "ldapquery::search() LDAP ERROR encountered: #{e.message}"
+      return nil
+    end
+
+    Puppet.debug "ldapquery::search() LDAP search result was: #{ldap.get_operation_result.code}:#{ldap.get_operation_result.message}"
+
+    time_delta = format('%.3f', Time.now - start_time)
+    Puppet.debug("ldapquery::search(): Searching #{search_args[:base]} for #{search_args[:attributes]} using #{search_args[:filter]} took #{time_delta} seconds and returned #{results.length} results")
+
+    results
+  end
+
+  def format_entry(entry)
+    entry_data = {}
+    entry.each do |attribute, values|
+      attr = attribute.to_s
+      value_data = []
+      Array(values).flatten.each do |v|
+        value_data << v.to_s.chomp
+      end
+      entry_data[attr] = value_data
+    end
+    entry_data
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -13,5 +13,81 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "dependencies": []
+  "dependencies": [],
+	"operatingsystem_support": [
+		{
+			"operatingsystem": "Debian",
+			"operatingsystemrelease": [
+				"10",
+				"11"
+			]
+		},
+		{
+			"operatingsystem": "OpenBSD"
+		},
+		{
+			"operatingsystem": "RedHat",
+			"operatingsystemrelease": [
+				"7",
+				"8",
+				"9"
+			]
+		},
+		{
+			"operatingsystem": "Rocky",
+			"operatingsystemrelease": [
+				"8",
+				"9"
+			]
+		},
+		{
+			"operatingsystem": "AlmaLinux",
+			"operatingsystemrelease": [
+				"8",
+				"9"
+			]
+		},
+		{
+			"operatingsystem": "CentOS",
+			"operatingsystemrelease": [
+				"7",
+				"8",
+				"9"
+			]
+		},
+		{
+			"operatingsystem": "VirtuozzoLinux",
+			"operatingsystemrelease": [
+				"6",
+				"7"
+			]
+		},
+		{
+			"operatingsystem": "SLES"
+		},
+		{
+			"operatingsystem": "Solaris"
+		},
+		{
+			"operatingsystem": "AIX"
+		},
+		{
+			"operatingsystem": "FreeBSD"
+		},
+		{
+			"operatingsystem": "DragonFly"
+		},
+		{
+			"operatingsystem": "NetBSD"
+		},
+		{
+			"operatingsystem": "Ubuntu",
+			"operatingsystemrelease": [
+				"18.04",
+				"20.04",
+				"22.04",
+				"24.04"
+			]
+		}
+	]
 }

--- a/spec/acceptance/ldapquery_spec.rb
+++ b/spec/acceptance/ldapquery_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'ldapquery::search function' do
+  context 'basic usage' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-MANIFEST
+          file { '/tmp/testoutput':
+            ensure  => file,
+            content => ldapquery::search(
+              'dc=example,dc=org',
+              '(objectClass=posixAccount)',
+              ['uid'],
+              {
+                host       => 'openldap',
+                port       => 1389,
+                auth       => {
+                  method   => simple,
+                  username => 'cn=user01,ou=users,dc=example,dc=org',
+                  password => 'bitnami1',
+                },
+              },
+            ).to_json_pretty
+          }
+        MANIFEST
+      end
+      describe file('/tmp/testoutput') do
+        it { is_expected.to be_file }
+
+        its(:content_as_json) do
+          is_expected.to eq(
+            [
+              {
+                'dn' => [
+                  'cn=user01,ou=users,dc=example,dc=org'
+                ],
+                'uid' => [
+                  'user01'
+                ]
+              },
+              {
+                'dn' => [
+                  'cn=user02,ou=users,dc=example,dc=org'
+                ],
+                'uid' => [
+                  'user02'
+                ]
+              }
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/functions/ldapquery/search_spec.rb
+++ b/spec/functions/ldapquery/search_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ldapquery::search' do
+  it 'exists' do
+    is_expected.not_to be_nil
+  end
+end

--- a/spec/scripts/start-openldap.sh
+++ b/spec/scripts/start-openldap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+docker run --detach --rm \
+  --name openldap \
+  --hostname openldap \
+  --publish 1389:1389 \
+  --publish 1636:1636 \
+  bitnami/openldap
+
+sleep 5
+docker logs openldap --tail 100
+
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' openldap > ~/OPENLDAP_IP

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,9 @@
+file_line { '/etc/hosts-openldap':
+  path => '/etc/hosts',
+  line => "${facts['openldap_ip']} openldap",
+}
+
+package { 'net-ldap':
+  ensure   => present,
+  provider => 'puppet_gem',
+}

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+ENV['BEAKER_FACTER_OPENLDAP_IP'] = File.read(File.expand_path('~/OPENLDAP_IP')).chomp
+
+configure_beaker do |host|
+  install_puppet_module_via_pmt_on(host, 'puppetlabs-stdlib')
+end


### PR DESCRIPTION
Sourcing ldap server configuration options from puppet.conf was conflating their original purpose, and a future release of Puppet may even remove these options.

It's still desirable to be able to set defaults for the function from a file, but a dedicated yaml file is far more flexible than an ini file.

In this commit, a new `ldapquery::search` function is added with a new implementation. The old version is kept, but marked as DEPRECATED.